### PR TITLE
fix: Run semantic-release on node 10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,16 @@ cache:
     - ~/.npm
 notifications:
   email: false
+install: npm install --skip-optional
 node_js:
   - '10'
   - '9'
   - '8'
   - '6'
 after_success:
+  - nvm install 10
+  - nvm use 10
+  - npm install
   - npm run travis-deploy-once "npm run semantic-release"
 branches:
   except:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "travis-deploy-once": "travis-deploy-once"
   },
   "devDependencies": {
-    "@mike-works/workshop-semantic-release-config": "^1.0.0",
     "@types/express": "^4.16.0",
     "@types/react": "^16.4.11",
     "@types/react-dom": "^16.0.7",
@@ -63,7 +62,6 @@
     "react-router-dom": "^4.3.1",
     "react-test-renderer": "^16.4.2",
     "sass-loader": "^6.0.7",
-    "semantic-release": "^15.9.9",
     "style-ext-html-webpack-plugin": "^3.4.7",
     "style-loader": "^0.20.3",
     "travis-deploy-once": "^5.0.2",
@@ -74,6 +72,10 @@
     "webpack-hot-middleware": "^2.22.3",
     "webpack-manifest-plugin": "^1.3.2",
     "worker-loader": "^1.1.1"
+  },
+  "optionalDependencies": {
+    "semantic-release": "^15.9.9",
+    "@mike-works/workshop-semantic-release-config": "^1.0.0"
   },
   "dependencies": {
     "body-parser": "^1.18.3",


### PR DESCRIPTION
Semantic release requires `node >= 8.3`, and we support node 6. Thus, we need to consistently run the semantic-release command on a modern version of node, regardless of which node environment tests are running on.