### PR TITLE
Update webpack settings (uglify plugin, compression plugin, mode)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "travis-deploy-once": "travis-deploy-once"
   },
   "devDependencies": {
-    "babel-core": "7.0.0-bridge.0",
     "@babel/preset-env": "7.1.6",
     "@babel/preset-react": "7.0.0",
     "@mike-works/js-lib-renovate-config": "2.0.0",
@@ -39,6 +38,7 @@
     "@types/react": "16.7.7",
     "@types/react-dom": "16.0.10",
     "@types/sequelize": "4.27.31",
+    "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",
     "babel-loader": "8.0.4",
@@ -70,6 +70,7 @@
     "travis-deploy-once": "5.0.9",
     "webpack": "4.26.1",
     "webpack-bundle-analyzer": "3.0.3",
+    "webpack-cli": "^3.1.2",
     "webpack-dev-middleware": "3.4.0",
     "webpack-dev-server": "3.1.10",
     "webpack-hot-middleware": "2.24.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,13 +5,15 @@ const moduleConfig = require('./webpack/module.config');
 const plugins = require('./webpack/plugins.config');
 const devServer = require('./webpack/devserver.config');
 
-module.exports = function() {
+module.exports = function(env) {
+  const mode = (env === 'dev') ? 'development' : 'production';
+
   return {
     entry: ['webpack-hot-middleware/client', './client/index.js'],
     stats: {
       colors: true
     },
-    mode: 'development',
+    mode,
     resolve: {
       extensions: ['.js', '.jsx']
     },

--- a/webpack/plugins.config.js
+++ b/webpack/plugins.config.js
@@ -30,23 +30,6 @@ module.exports = function(env, options) {
       })
     );
     plugins.push(
-      new webpack.optimize.UglifyJsPlugin({
-        sourceMap:
-          options.devtool &&
-          (options.devtool.indexOf('sourcemap') >= 0 ||
-            options.devtool.indexOf('source-map') >= 0),
-        beautify: false,
-        mangle: {
-          screw_ie8: true,
-          keep_fnames: true
-        },
-        compress: {
-          screw_ie8: true
-        },
-        comments: false
-      })
-    );
-    plugins.push(
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify('production')
       })

--- a/webpack/plugins.config.js
+++ b/webpack/plugins.config.js
@@ -36,14 +36,11 @@ module.exports = function(env, options) {
     );
     plugins.push(
       new CompressionPlugin({
-        asset: '[path].gz',
+        filename: '[path].gz',
         algorithm: 'gzip',
         test: /\.(js|html)$/,
         threshold: 10240,
         minRatio: 0.8,
-        compress: {
-          warnings: false
-        }
       })
     );
   } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3592,7 +3592,7 @@ decamelize-keys@^1.0.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2:
+decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -5158,6 +5158,11 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
+global-modules-path@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/global-modules-path/-/global-modules-path-2.3.0.tgz#b0e2bac6beac39745f7db5c59d26a36a0b94f7dc"
+  integrity sha512-HchvMJNYh9dGSCy8pOQ2O8u/hoXaL+0XhnrwH0RyLiSXMMTl9W3N6KUU73+JFOg5PGjtzl6VZzUQsnrpm7Szag==
+
 global@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
@@ -5881,6 +5886,11 @@ internal-ip@^3.0.1:
   dependencies:
     default-gateway "^2.6.0"
     ipaddr.js "^1.5.2"
+
+interpret@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
+  integrity sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=
 
 into-stream@^4.0.0:
   version "4.0.0"
@@ -10969,7 +10979,7 @@ supports-color@^4.1.0:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.1.0, supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.1.0, supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -11614,6 +11624,11 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
+v8-compile-cache@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz#a428b28bb26790734c4fc8bc9fa106fccebf6a6c"
+  integrity sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==
+
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -11755,6 +11770,22 @@ webpack-bundle-analyzer@3.0.3:
     mkdirp "^0.5.1"
     opener "^1.5.1"
     ws "^6.0.0"
+
+webpack-cli@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.1.2.tgz#17d7e01b77f89f884a2bbf9db545f0f6a648e746"
+  integrity sha512-Cnqo7CeqeSvC6PTdts+dywNi5CRlIPbLx1AoUPK2T6vC1YAugMG3IOoO9DmEscd+Dghw7uRlnzV1KwOe5IrtgQ==
+  dependencies:
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    enhanced-resolve "^4.1.0"
+    global-modules-path "^2.3.0"
+    import-local "^2.0.0"
+    interpret "^1.1.0"
+    loader-utils "^1.1.0"
+    supports-color "^5.5.0"
+    v8-compile-cache "^2.0.2"
+    yargs "^12.0.2"
 
 webpack-dev-middleware@3.4.0:
   version "3.4.0"
@@ -12108,6 +12139,14 @@ yargs-parser@^10.1.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
+  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
@@ -12175,6 +12214,24 @@ yargs@^12.0.0, yargs@^12.0.1:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^10.1.0"
+
+yargs@^12.0.2:
+  version "12.0.5"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
+  integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^1.0.1"
+    os-locale "^3.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1 || ^4.0.0"
+    yargs-parser "^11.1.1"
 
 yargs@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
This is in regards to : #199 
I’ve removed source map option from minimizer as it’s always going to be undefined (options argument is not passed to plugins

Uglify:
Beautify and screw_ie8  option are not present in webpack 4 plugin
`(ERROR in main-80922a5996c398e381b3.js from UglifyJs
DefaultsError: `screw_ie8` is not a supported option)`

It doesn’t look like anything from UglifyJsPlugin overwrites the defaults in meaningful way. I would suggest to use default webpack optimization

348kb - bundle size while keeping current uglifyjs plugin settings:
343kb - default webpack production settings


Compression plugin
Compress is no longer valid option. 
There’s no warning word in [compresion plugin docs](https://webpack.js.org/plugins/compression-webpack-plugin/#options)

Other:
I've taken liberty of adding mode handling. Currently all scripts were using development mode, missing some optimizations. Now it's resolved using env.
I also added webpack-cli as it's required from webpack 4 to work.
